### PR TITLE
Fix `no such column` issue

### DIFF
--- a/updates/1_3_12_update_initbiz_cumuluscore_cluster_user_table.php
+++ b/updates/1_3_12_update_initbiz_cumuluscore_cluster_user_table.php
@@ -9,6 +9,8 @@ class UpdateInitbizCumuluscoreClusterUserTable extends Migration
     {
         Schema::table('initbiz_cumuluscore_cluster_user', function ($table) {
             $table->renameColumn('user_id', 'user_id_tmp');
+        });
+        Schema::table('initbiz_cumuluscore_cluster_user', function ($table) {
             $table->renameColumn('cluster_id', 'user_id');
         });
         Schema::table('initbiz_cumuluscore_cluster_user', function ($table) {
@@ -20,6 +22,8 @@ class UpdateInitbizCumuluscoreClusterUserTable extends Migration
     {
         Schema::table('initbiz_cumuluscore_cluster_user', function ($table) {
             $table->renameColumn('user_id', 'user_id_tmp');
+        });
+        Schema::table('initbiz_cumuluscore_cluster_user', function ($table) {
             $table->renameColumn('cluster_id', 'user_id');
         });
         Schema::table('initbiz_cumuluscore_cluster_user', function ($table) {

--- a/updates/2_0_0_update_initbiz_cumuluscore_clusters_table_3.php
+++ b/updates/2_0_0_update_initbiz_cumuluscore_clusters_table_3.php
@@ -9,6 +9,8 @@ class UpdateInitbizCumuluscoreClustersTable3 extends Migration
     {
         Schema::table('initbiz_cumuluscore_clusters', function ($table) {
             $table->renameColumn('cluster_id', 'id');
+        });
+        Schema::table('initbiz_cumuluscore_clusters', function ($table) {
             $table->renameColumn('full_name', 'name');
         });
     }
@@ -17,6 +19,8 @@ class UpdateInitbizCumuluscoreClustersTable3 extends Migration
     {
         Schema::table('initbiz_cumuluscore_clusters', function ($table) {
             $table->renameColumn('id', 'cluster_id');
+        });
+        Schema::table('initbiz_cumuluscore_clusters', function ($table) {
             $table->renameColumn('name', 'full_name');
         });
     }


### PR DESCRIPTION
When I'm running unit tests cumuluscore-plugin's refresh fails. 

Example for step 1.3.12: 
```
Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such column: user_id (SQL: CREATE TEMPORARY TABLE __temp__initbiz_cumuluscore_cluster_user AS SELECT user_id, cluster_id FROM initbiz_cumuluscore_cluster_user)
``` 
and 2.0.0
```
Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such column: cluster_id (SQL: CREATE TEMPORARY TABLE __temp__initbiz_cumuluscore_clusters AS SELECT cluster_id, plan_id, full_name, slug, thoroughfare, city, phone, country_id, postal_code, description, email, tax_number, account_number FROM initbiz_cumuluscore_clusters)
```

By splitting renameColumn steps it resolves the issue :) 